### PR TITLE
More warning resolutions

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+ ((nil . ((indent-tabs-mode . nil)
+          (tab-width . 4)
+		  (rust-indent-offset . 4))))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(alloc)]
 
 #![feature(arc_counts)]
+#![feature(test)]
 pub use latch::Latch;
 pub use promise::{Promise,Promisee,Promiser};
 


### PR DESCRIPTION
Gets the tests running again (`#![feature(test)]` is still needed). Fixes the warnings in the tests. T for Send needs Sync. (`rustc --explain E0277`).
